### PR TITLE
Removed docker hub image & update info

### DIFF
--- a/en-us/01-intro/2-Installing.md
+++ b/en-us/01-intro/2-Installing.md
@@ -2,7 +2,8 @@
 
 ## Easy Mode
 
-There's a [Docker image](https://hub.docker.com/r/co60ca/airship/) available to use.
+There's a docker-compose.yml file in [the main repo](https://github.com/paragonie/airship) that used along side with
+docker-compose will build and run the necessary software. See [the official docker documentation](https://docs.docker.com/compose/overview/) for details on how to utilize the docker-compose.
 
 ## Manual Installation
 


### PR DESCRIPTION
Since we moved to docker-compose using docker hub for the image isn't useful as far as I know, in the future we can do this again or add more details about docker-compose but until then I'm leaving it to the user to learn how to use docker-compose. Mostly since Its new to me.

The docker image I put on docker hub is no longer available.
